### PR TITLE
Попытка фикса состояния экрана поиска

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/presentation/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/SearchViewModel.kt
@@ -1,6 +1,5 @@
 package ru.practicum.android.diploma.presentation
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -19,15 +18,12 @@ class SearchViewModel(
     private val vacancyInteractor: VacancyInteractor,
     private val filterInteractor: FilterSpInteractor
 ) : ViewModel() {
-    // Это "кусочек" поискового запроса, который отдает нам АПИ
     private val vacancyLiveData = MutableLiveData<VacancyState?>()
     fun observeVacancy(): LiveData<VacancyState?> = vacancyLiveData
 
     private val inputLiveData = MutableLiveData<String>()
     fun observeInput(): LiveData<String> = inputLiveData
 
-    // Эти три строки отвечают за состояние экрана поиска по возврату на него
-    // vacancyState - это "склад", где мы храним все вакансии по запросу
     private val vacancyState = mutableListOf<Vacancy>()
     private val vacancyStateLiveData = MutableLiveData<Pair<List<Vacancy>, Int>>()
     fun observeState(): LiveData<Pair<List<Vacancy>, Int>> = vacancyStateLiveData
@@ -51,7 +47,6 @@ class SearchViewModel(
     }
 
     private fun search(text: String) {
-        Log.d("RENDER", "search")
         if (text.isNotEmpty()) {
             var state: VacancyState = VacancyState.Loading(false)
             vacancyLiveData.postValue(state)
@@ -72,7 +67,6 @@ class SearchViewModel(
     }
 
     fun loadMoreVacancies(text: String) {
-        Log.d("RENDER", "loadMoreVacancies")
         var state: VacancyState = VacancyState.Loading(true)
         vacancyLiveData.postValue(state)
 

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/SearchViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import ru.practicum.android.diploma.domain.api.FilterSpInteractor
@@ -21,8 +20,8 @@ class SearchViewModel(
     private val filterInteractor: FilterSpInteractor
 ) : ViewModel() {
     // Это "кусочек" поискового запроса, который отдает нам АПИ
-    private val vacancyLiveData = MutableLiveData<VacancyState>()
-    fun observeVacancy(): LiveData<VacancyState> = vacancyLiveData
+    private val vacancyLiveData = MutableLiveData<VacancyState?>()
+    fun observeVacancy(): LiveData<VacancyState?> = vacancyLiveData
 
     private val inputLiveData = MutableLiveData<String>()
     fun observeInput(): LiveData<String> = inputLiveData
@@ -49,12 +48,6 @@ class SearchViewModel(
 
     fun searchAnyway(text: String) {
         vacancySearchDebounce(text)
-    }
-
-    fun delayToast() {
-        runBlocking {
-            delay(TOAST_DELAY)
-        }
     }
 
     private fun search(text: String) {
@@ -101,6 +94,10 @@ class SearchViewModel(
         vacancyStateLiveData.postValue(vacancyState to itemsFound)
     }
 
+    fun clearLastSearchResult() {
+        vacancyLiveData.value = null
+    }
+
     private fun createFilteredQuery(text: String): HashMap<String, String> {
         val filter: Filter = filterInteractor.output()
         val filteredQuery = HashMap<String, String>()
@@ -144,6 +141,5 @@ class SearchViewModel(
 
     companion object {
         private const val DEBOUNCE_DELAY = 2000L
-        private const val TOAST_DELAY = 1000L
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/SearchViewModel.kt
@@ -96,7 +96,6 @@ class SearchViewModel(
         }
     }
 
-
     private fun updateState(vacancyList: List<Vacancy>, itemsFound: Int) {
         vacancyState.addAll(vacancyList)
         vacancyStateLiveData.postValue(vacancyState to itemsFound)


### PR DESCRIPTION
Ввод в проблему для тех, кто не знает:
В предыдущей реализации при выходе с экрана поиска и возвращении обратно мы видели только те вакансии, которые загрузили последними. То есть, если мы ввели запрос, проскроллили 10 страниц, вышли с экрана и вернулись обратно, то нам были видны не все 10 страниц, а только последняя 10-я страница. Я считаю это некорректной работой приложения, и если ревьювер внимательный, то он это заметит

Решение проблемы:
Я решил складировать все результаты поиска в один список во вьюмодели. Туда попадает как результат первичного поиска, так и результат поиска после скролла. То есть, если мы решили поискать вакансии, и потом 4 раза догрузили их с сервера, проскроллив вниз, то на "складе" будет 100 вакансий (каждый ответ от сервера содержит 20 вакансий). Если мы уходим с экрана поиска на другой экран из bottomNavigation, и возвращаемся на экран поиска, то получаем вакансии со склада. Но там есть одна проблема, которую я подписал комментариями к коду. Если коротко, то в текущей реализации мы сначала идем на "склад" за вакансиями, отрисовываем их, а потом добавляем последнюю поисковую выдачу. Как это обойти я не придумал, надеюсь на вашу помощь

P.S. Настоятельно рекомендую скачать мою ветку к себе на комп и поиграться с логами. К тому же, так проще смотреть код и пробовать свои идеи
<img width="347" height="364" alt="image" src="https://github.com/user-attachments/assets/336a86c1-4a78-41f9-bbf7-dafd1764c784" />
